### PR TITLE
BUG/TEST: Corrected name performance CI tests.

### DIFF
--- a/ci/run-performance-tests.ps1
+++ b/ci/run-performance-tests.ps1
@@ -27,7 +27,7 @@ try {
             DetectionsPerSecond = $Results.DetectionsPerSecond
         };
         LowerIsBetter = @{
-            AvgMillisecsPerDetection = $Results.AvgMillisecsPerDetection
+            AvgMillisecsPerDetection = $Results.MsPerDetection
         }
     } | ConvertTo-Json | Out-File $perfSummary/results_$Name.json
 } finally {


### PR DESCRIPTION
The incorrect key was used when reading the performance results. This is now correct.