### PR TITLE
Add tox pre-publish configs

### DIFF
--- a/fiftyone_devicedetection_cloud/tox.ini
+++ b/fiftyone_devicedetection_cloud/tox.ini
@@ -13,3 +13,12 @@ commands =
 pass_env =
     resource_key
     license_key
+
+[testenv:pre-publish]
+package = skip
+deps =
+    pytest>=6
+    pytest-cov
+    -r ../../package/pre-publish-requirements.txt
+commands =
+    pytest --cov=. --import-mode=append {tty:--color=yes} {posargs}

--- a/fiftyone_devicedetection_examples/tox.ini
+++ b/fiftyone_devicedetection_examples/tox.ini
@@ -21,3 +21,11 @@ pass_env =
     resource_key
     license_key
     run_performance_tests
+
+[testenv:pre-publish]
+deps =
+    pytest>=6
+    pytest-cov
+    -r ../../package/pre-publish-requirements.txt
+commands =
+    pytest --cov=. --import-mode=append {tty:--color=yes} {posargs}

--- a/fiftyone_devicedetection_onpremise/tox.ini
+++ b/fiftyone_devicedetection_onpremise/tox.ini
@@ -17,3 +17,13 @@ commands =
 pass_env =
     resource_key
     license_key
+
+[testenv:pre-publish]
+package = skip
+deps =
+    pytest>=6
+    pytest-cov
+    flask
+    -r ../../package/pre-publish-requirements.txt
+commands =
+    pytest --cov=. --import-mode=append {tty:--color=yes} {posargs}


### PR DESCRIPTION
These configs will be used during `publish` pipeline to enable use of prebuilt packages
