### PR TITLE
Build the c module in a custom temp dir

### DIFF
--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -5,6 +5,12 @@ param (
     [Hashtable]$Keys
 )
 
+if ($IsWindows) {
+    # Shorten the temporary directory path to work around MSVC path lenght limit
+    $env:TEMP = New-Item -ItemType Directory -Force -Path "C:\tmp"
+    Write-Output $env:TEMP
+}
+
 $packages = "fiftyone_devicedetection_cloud", "fiftyone_devicedetection_examples"
 
 if (!$Keys.TestResourceKey) {

--- a/ci/run-unit-tests.ps1
+++ b/ci/run-unit-tests.ps1
@@ -3,6 +3,12 @@ param (
     [string]$RepoName
 )
 
+if ($IsWindows) {
+    # Shorten the temporary directory path to work around MSVC path lenght limit
+    $env:TEMP = New-Item -ItemType Directory -Force -Path "C:\tmp"
+    Write-Output $env:TEMP
+}
+
 $packages = "fiftyone_devicedetection_onpremise"
 ./python/run-unit-tests.ps1 -RepoName $RepoName -Packages $packages
 

--- a/fiftyone_devicedetection_onpremise/tox.ini
+++ b/fiftyone_devicedetection_onpremise/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 minversion = 4.0
+;work_dir = {tox_root}/../../.tox_premise
 
 [common]
 deps =
@@ -26,6 +27,9 @@ commands =
 pass_env =
     resource_key
     license_key
+    TMPDIR
+    TEMP
+    TMP
 
 [testenv:pre-publish]
 package = skip


### PR DESCRIPTION
MSVC has a path length limit of 260 bytes, which cannot be increased. When building the device-detection-cxx native extension, setuptools places object files in a very long location, that MSVC cannot open due to said limit. To work around this limitation, we create another alternative directory, with a shorter path compared to the default, and set it as TEMP dir.