### PR TITLE
fix(build): shorten Doxygen titles and noindex generated index pages

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -163,7 +163,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand
@@ -1470,6 +1470,7 @@ DISABLE_INDEX          = YES
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
 GENERATE_TREEVIEW      = YES
+HTML_INDEX_NOINDEX     = YES
 
 # The HIDE_TREEVIEW_ROOT tag is used to remove the root node from the tree view.
 # When not hidden, the tree root will be PROJECT_NAME. If the tree root is set


### PR DESCRIPTION
fix(build): shorten Doxygen titles and noindex generated index pages

Sets FULL_PATH_NAMES = NO so the generated directory and file page titles no
longer embed the full CI build path, and enables HTML_INDEX_NOINDEX = YES so
Doxygen's generated navigation, index and helper pages (dir_*.html, pages.html,
the crawler helper and the graph legend) carry
<meta name="robots" content="noindex,follow">.

These thin, link-only pages are flagged as low-quality content by search
engines. The change keeps them out of the search index while crawlers still
follow their links to the real documentation. Part of the SEMrush documentation
audit remediation (issues 102, 112, 117).

HTML_INDEX_NOINDEX requires the updated 51Degrees DoxyGen build
(51Degrees/doxygen#7); older builds ignore the tag with a harmless warning.
