### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,9 +4,9 @@ This API complies with the `common-ci` approach.
 The following secrets are required:
 * `ACCESS_TOKEN` - GitHub [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) for cloning repos, creating PRs, etc.
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (TAC hashes file and TAC CSV data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for downloading assets (TAC hashes file and TAC CSV data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`
 * `PYPI_TOKEN` - [PyPI token](https://pypi.org/help/#apitoken) for publishing packages
     * Example: `pypi-sUp3r-l0nG_r4nd0m-s7r1Ng`

--- a/fiftyone_devicedetection/readme.md
+++ b/fiftyone_devicedetection/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees Device Detection Engines - Device Detection
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection-readme.md&utm_term=51degrees-device-detection-engines-device-detection "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
 
-[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "View all available properties and values")
+[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection-readme.md&utm_term=51degrees-device-detection-engines-device-detection "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection-readme.md&utm_term=51degrees-device-detection-engines-device-detection "View all available properties and values")
 
 ## Introduction
 

--- a/fiftyone_devicedetection/setup.py
+++ b/fiftyone_devicedetection/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     version=read("version.txt"),
     author="51Degrees Engineering",
     author_email="engineering@51degrees.com",
-    url="https://51degrees.com/",
+    url="https://51degrees.com/?utm_source=pypi&utm_medium=package&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection-setup.py&utm_term=url",
     description=("51Degrees Device Detection parses HTTP headers to return detailed hardware, operating system, browser, and crawler information for the devices used to access your website or service. This is an alternative to popular UAParser, DeviceAtlas, and WURFL packages."),
     long_description=read("readme.md"),
     long_description_content_type='text/markdown',

--- a/fiftyone_devicedetection_cloud/readme.md
+++ b/fiftyone_devicedetection_cloud/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees Device Detection Engines - Cloud
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_cloud-readme.md&utm_term=51degrees-device-detection-engines-cloud "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
 
-[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "View all available properties and values")
+[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_cloud-readme.md&utm_term=51degrees-device-detection-engines-cloud "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_cloud-readme.md&utm_term=51degrees-device-detection-engines-cloud "View all available properties and values")
 
 ## Introduction
 
@@ -12,7 +12,7 @@
 
 You can confirm this is working with the following micro-example.
 
-* Create a resource key for free with the 51Degrees [configurator](https://configure.51degrees.com/np5M4nlF). This defines the properties you want to access.
+* Create a resource key for free with the 51Degrees [configurator](https://configure.51degrees.com/np5M4nlF?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_cloud-readme.md&utm_term=from-pypi). This defines the properties you want to access.
 * On the 'implement' page of the configurator, copy the resource key and replace YOUR_RESOURCE_KEY in the example below. Save this as exampledd.py
 * Run the example with `python exampledd.py`
 * Feel free to try different user-agents and property values.
@@ -26,7 +26,7 @@ fd.process()
 print(fd.device.ismobile.value())
 ```
 
-For more in-depth examples, check out the [examples](https://51degrees.com/device-detection-python/examples.html) page in the documentation.
+For more in-depth examples, check out the [examples](https://51degrees.com/device-detection-python/examples.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_cloud-readme.md&utm_term=from-pypi) page in the documentation.
 
 ### From GitHub
 

--- a/fiftyone_devicedetection_cloud/setup.py
+++ b/fiftyone_devicedetection_cloud/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     version=read("version.txt"),
     author="51Degrees Engineering",
 	author_email="engineering@51degrees.com",
-    url="https://51degrees.com/",
+    url="https://51degrees.com/?utm_source=pypi&utm_medium=package&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_cloud-setup.py&utm_term=url",
     description=("51Degrees Device Detection parses HTTP headers to return detailed hardware, operating system, browser, and crawler information for the devices used to access your website or service. This package retrieves device detection results by consuming the 51Degrees cloud service."),
     long_description=read("readme.md"),
     long_description_content_type='text/markdown',

--- a/fiftyone_devicedetection_examples/readme.md
+++ b/fiftyone_devicedetection_examples/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees Device Detection Engines - Examples
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-readme.md&utm_term=51degrees-device-detection-engines-examples "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
 
-[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "View all available properties and values")
+[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-readme.md&utm_term=51degrees-device-detection-engines-examples "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-readme.md&utm_term=51degrees-device-detection-engines-examples "View all available properties and values")
 
 ## Introduction
 

--- a/fiftyone_devicedetection_examples/setup.py
+++ b/fiftyone_devicedetection_examples/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     version=read("version.txt"),
     author="51Degrees Engineering",
     author_email="engineering@51degrees.com",
-    url="https://51degrees.com/",
+    url="https://51degrees.com/?utm_source=pypi&utm_medium=package&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-setup.py&utm_term=url",
     description=("The 51Degrees Pipeline API is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines). "
     "This project contains examples of using 51Degrees Device Detection engines with the Pipeline API"),
     long_description=read("readme.md"),

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/configurator_console.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/configurator_console.py
@@ -25,13 +25,13 @@ from fiftyone_pipeline_core.logger import Logger
 from fiftyone_devicedetection.devicedetection_pipelinebuilder import DeviceDetectionPipelineBuilder
 from fiftyone_devicedetection_examples.example_utils import ExampleUtils
 
-# This example is displayed at the end of the [Configurator](https://configure.51degrees.com/)
+# This example is displayed at the end of the [Configurator](https://configure.51degrees.com/?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-configurator_console.py&utm_term=top)
 # process, which is used to create resource keys for use with the 51Degrees cloud service.
 # 
 # It shows how to call the cloud with the newly created key and how to access the values 
 # of the selected properties.
 #
-# See [Getting Started](https://51degrees.com/documentation/_examples__device_detection__getting_started__console__cloud.html)
+# See [Getting Started](https://51degrees.com/documentation/_examples__device_detection__getting_started__console__cloud.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-configurator_console.py&utm_term=top)
 # for a fuller example.
 #
 # Required PyPi Dependencies:
@@ -92,10 +92,10 @@ def main(argv):
             f"'{ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees " +
             "cloud service is accessed using a 'ResourceKey'. " +
             "For more detail see " +
-            "http://51degrees.com/documentation/4.3/_info__resource_keys.html. " +
+            "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-configurator_console.py&utm_term=resource-key-required. " +
             "A resource key with the properties required by this " +
             "example can be created for free at " +
-            "https://configure.51degrees.com/1QWJwHxl. " +
+            "https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-configurator_console.py&utm_term=resource-key-required. " +
             "Once complete, populate the environment variable " +
             "mentioned at the start of this message with the key.")
 

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/failuretomatch.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/failuretomatch.py
@@ -24,7 +24,7 @@ from fiftyone_devicedetection_cloud.devicedetection_cloud_pipelinebuilder import
 
 # First create the device detection pipeline with the desired settings.
 
-# You need to create a resource key at https://configure.51degrees.com
+# You need to create a resource key at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-failuretomatch.py&utm_term=top
 # and paste it into the code, replacing !!YOUR_RESOURCE_KEY!! below.
 # Alternatively, add a resource_key environment variable
 import os
@@ -36,9 +36,9 @@ else:
 if resource_key == "!!YOUR_RESOURCE_KEY!!":
     print("""
     You need to create a resource key at
-    https://configure.51degrees.com and paste it into the code,
+    https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-failuretomatch.py&utm_term=resource-key-required and paste it into the code,
     'replacing !!YOUR_RESOURCE_KEY!!
-    To include the properties used in this example, go to https://configure.51degrees.com/bxXqZhLT
+    To include the properties used in this example, go to https://configure.51degrees.com/bxXqZhLT?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-failuretomatch.py&utm_term=resource-key-required
     """)
 else:
 

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/gettingstarted_console.json
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/gettingstarted_console.json
@@ -7,7 +7,7 @@
                 "elementParameters": {
                     "settings": {
                         // Obtain a resource key with the properties required to run this 
-                        // example for free: https://configure.51degrees.com/1QWJwHxl
+                        // example for free: https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_console.json&utm_term=settings
                         "resource_key": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
                         "cloud_request_origin": "51Degrees.example.com"
                     }

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/gettingstarted_console.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/gettingstarted_console.py
@@ -51,7 +51,7 @@ class GettingStartedConsole():
 
         # In this example, we use the PipelineBuilder and configure it from a file.
         # For more information about builders in general see the documentation at
-        # https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        # https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_console.py&utm_term=run
 
         # Create the pipeline using the service provider and the configured options.
         pipeline = PipelineBuilder().add_logger(logger).build_from_configuration(config)
@@ -97,7 +97,7 @@ class GettingStartedConsole():
 
         # Display the results of the detection, which are called
         # device properties. See the property dictionary at
-        # https://51degrees.com/developers/property-dictionary
+        # https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_console.py&utm_term=analyseevidence
         # for details of all available properties.
         self.outputValue("Mobile Device", device.ismobile, message)
         self.outputValue("Platform Name", device.platformname, message)
@@ -175,9 +175,9 @@ def main(argv):
             f"'{ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees cloud " +
             "service is accessed using a 'ResourceKey'. For more information " +
             "see " +
-            "https://51degrees.com/documentation/_info__resource_keys.html. " +
+            "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_console.py&utm_term=resource-key-required. " +
             "A resource key with the properties required by this example can be " +
-            "created for free at https://configure.51degrees.com/1QWJwHxl. " +
+            "created for free at https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_console.py&utm_term=resource-key-required. " +
             "Once complete, populate the config file or environment variable " +
             "mentioned at the start of this message with the key.")
     else:

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/gettingstarted_web/app.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/gettingstarted_web/app.py
@@ -58,7 +58,7 @@
 # ```
 # 
 # Results can also be accessed in client-side code by using the `fod` object. See the 
-# [JavaScriptBuilderElementBuilder](https://51degrees.com/pipeline-python/4.3/classpipeline-python_1_1fiftyone__pipeline__core_1_1fiftyone__pipeline__core_1_1javascriptbuilde778a9036818b19ab55d981a40be4a4d7.html)
+# [JavaScriptBuilderElementBuilder](https://51degrees.com/pipeline-python/4.3/classpipeline-python_1_1fiftyone__pipeline__core_1_1fiftyone__pipeline__core_1_1javascriptbuilde778a9036818b19ab55d981a40be4a4d7.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_web-app.py&utm_term=top)
 # for details on available settings such as changing the `fod` name.
 # ```{js}
 # window.onload = function () {
@@ -166,7 +166,7 @@ class GettingStartedWeb():
         # requested. So set whatever headers are required by the browser in
         # order to return the evidence needed by the pipeline.
         # More info on this can be found at
-        # https://51degrees.com/blog/user-agent-client-hints
+        # https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_web-app.py&utm_term=server
 
         set_response_header(flowdata, response)
 
@@ -196,10 +196,10 @@ def main(argv):
             f"'{ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees " +
             "cloud service is accessed using a 'ResourceKey'. " +
             "For more detail see " +
-            "http://51degrees.com/documentation/4.3/_info__resource_keys.html. " +
+            "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_web-app.py&utm_term=resource-key-required. " +
             "A resource key with the properties required by this " +
             "example can be created for free at " +
-            "https://configure.51degrees.com/g3gMZdPY. " +
+            "https://configure.51degrees.com/g3gMZdPY?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_web-app.py&utm_term=resource-key-required. " +
             "Once complete, populated the environment variable " +
             "mentioned at the start of this message with the key.")
 

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/metadata_console.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/metadata_console.py
@@ -120,10 +120,10 @@ def main(argv):
             f"'{ExampleUtils.RESOURCE_KEY_ENV_VAR}'. The 51Degrees " +
             "cloud service is accessed using a 'ResourceKey'. " +
             "For more detail see " +
-            "http://51degrees.com/documentation/4.3/_info__resource_keys.html. " +
+            "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-metadata_console.py&utm_term=resource-key-required. " +
             "A resource key with the properties required by this " +
             "example can be created for free at " +
-            "https://configure.51degrees.com/1QWJwHxl. " +
+            "https://configure.51degrees.com/1QWJwHxl?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-metadata_console.py&utm_term=resource-key-required. " +
             "Once complete, populate the environment variable " +
             "mentioned at the start of this message with the key.")
 

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/nativemodellookup_console.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/nativemodellookup_console.py
@@ -61,7 +61,7 @@ class NativeModelLookupConsole():
         # This example creates the pipeline and engines in code. For a demonstration
         # of how to do this using a configuration file instead, see the TacLookup example.
         # For more information about builders in general see the documentation at
-        # https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        # https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-nativemodellookup_console.py&utm_term=run
         cloudRequestEngineSettings = { "resource_key": resource_key }
 
         # If a cloud endpoint has been provided then set the
@@ -122,12 +122,12 @@ def main(argv):
             f"environment variable '{ExampleUtils.RESOURCE_KEY_ENV_VAR}'. " +
             "The 51Degrees cloud service is accessed using a 'ResourceKey'. " +
             "For more information " +
-            "see https://51degrees.com/documentation/_info__resource_keys.html. " +
+            "see https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-nativemodellookup_console.py&utm_term=resource-key-required. " +
             "Native model lookup is not available as a free service. This means that " +
             "you will first need a license key, which can be purchased from our " +
-            "pricing page: https://51degrees.com/pricing. Once this is done, a resource " +
+            "pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-nativemodellookup_console.py&utm_term=resource-key-required. Once this is done, a resource " +
             "key with the properties required by this example can be created at " +
-            "https://configure.51degrees.com/QKyYH5XT. You can now populate the " +
+            "https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-nativemodellookup_console.py&utm_term=resource-key-required. You can now populate the " +
             "environment variable mentioned at the start of this message with the " +
             "resource key or pass it as the first argument on the command line.")
 

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/taclookup_console.json
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/taclookup_console.json
@@ -7,8 +7,8 @@
         "elementParameters": {
           "settings": {
             // TAC lookup requires a license key, which can be purchased from our pricing page:
-            // https://51degrees.com/pricing. You can then obtain a resource key with the properties
-            // required to run this example here: https://configure.51degrees.com/QKyYH5XT
+            // https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-taclookup_console.json&utm_term=settings. You can then obtain a resource key with the properties
+            // required to run this example here: https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-taclookup_console.json&utm_term=settings
             "resource_key": "!!ENTER_YOUR_RESOURCE_KEY_HERE!!",
             // Update this with your domain name.
             "cloud_request_origin": "51Degrees.example.com"

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/taclookup_console.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/taclookup_console.py
@@ -62,7 +62,7 @@ class TacLookupConsole():
         # For a demonstration of how to do this in code instead, see the
         # NativeModelLookup example.
         # For more information about builders in general see the documentation at
-        # https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        # https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-taclookup_console.py&utm_term=run
 
         # Create the pipeline using the service provider and the configured options.
         pipeline = PipelineBuilder().add_logger(logger).build_from_configuration(config)
@@ -123,12 +123,12 @@ def main(argv):
             f"the environment variable '{ExampleUtils.RESOURCE_KEY_ENV_VAR}'. " +
             "The 51Degrees cloud service is accessed using a 'ResourceKey'. " +
             "For more information see " +
-            "https://51degrees.com/documentation/_info__resource_keys.html. " +
+            "https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-taclookup_console.py&utm_term=resource-key-required. " +
             "TAC lookup is not available as a free service. This means " +
             "that you will first need a license key, which can be purchased " +
-            "from our pricing page: https://51degrees.com/pricing. Once this is " +
+            "from our pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-taclookup_console.py&utm_term=resource-key-required. Once this is " +
             "done, a resource key with the properties required by this example " +
-            "can be created at https://configure.51degrees.com/QKyYH5XT. You " +
+            "can be created at https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-taclookup_console.py&utm_term=resource-key-required. You " +
             "can now populate the environment variable mentioned at the start " +
             "of this message with the resource key or pass it as the first " +
             "argument on the command line.")

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/useragentclienthints-web.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/useragentclienthints-web.py
@@ -24,7 +24,7 @@ from flask.helpers import make_response
 from fiftyone_devicedetection_cloud.devicedetection_cloud_pipelinebuilder import DeviceDetectionCloudPipelineBuilder
 from fiftyone_pipeline_core.web import webevidence, set_response_header
 
-# You need to create a resource key at https://configure.51degrees.com
+# You need to create a resource key at https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-useragentclienthints-web.py&utm_term=top
 # and paste it into the code, replacing !!YOUR_RESOURCE_KEY!! below.
 # Alternatively, add a resource_key environment variable
 import os
@@ -36,9 +36,9 @@ else:
 if resource_key == "!!YOUR_RESOURCE_KEY!!":
     print("""
     You need to create a resource key at
-    https://configure.51degrees.com and paste it into the code,
+    https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-useragentclienthints-web.py&utm_term=resource-key-required and paste it into the code,
     'replacing !!YOUR_RESOURCE_KEY!!
-    To include the properties used in this example, go to https://configure.51degrees.com/
+    To include the properties used in this example, go to https://configure.51degrees.com/?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-useragentclienthints-web.py&utm_term=resource-key-required
     """)
 else:
 
@@ -198,7 +198,7 @@ else:
         # requested. So set whatever headers are required by the browser in
         # order to return the evidence needed by the pipeline.
         # More info on this can be found at
-        # https://51degrees.com/blog/user-agent-client-hints
+        # https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-useragentclienthints-web.py&utm_term=server
 
         response = set_response_header(flowdata, response)
 

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/example_utils.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/example_utils.py
@@ -190,7 +190,7 @@ class ExampleUtils:
                 "https://github.com/51Degrees/device-detection-data. " +
                 "Find out about the Enterprise data file, which " +
                 "includes automatic updates, on our pricing page: " +
-                "https://51degrees.com/pricing")
+                "https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-example_utils.py&utm_term=data-file-age-warning")
 
         if ExampleUtils.get_data_file_tier(engine) == "Lite":
             logger.log("warning",
@@ -198,4 +198,4 @@ class ExampleUtils:
                 "data file. This is used for illustration, and " +
                 "has limited accuracy and capabilities. Find " +
                 "out about the Enterprise data file on our " +
-                "pricing page: https://51degrees.com/pricing")
+                "pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-example_utils.py&utm_term=lite-data-file")

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/datafileupdate_console.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/datafileupdate_console.py
@@ -33,11 +33,11 @@
 #
 # ## License Key
 # In order to test this example you will need a 51Degrees Enterprise license which can be
-# purchased from our [pricing page](//51degrees.com/pricing/annual). Look for our "Bigger" or
+# purchased from our [pricing page](https://51degrees.com/pricing/annual?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-datafileupdate_console.py&utm_term=top). Look for our "Bigger" or
 # "Biggest" options.
 #
 # # Data Files
-# You can find out more about data files, licenses etc. at our [FAQ page](//51degrees.com/resources/faqs)
+# You can find out more about data files, licenses etc. at our [FAQ page](https://51degrees.com/resources/faqs?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-datafileupdate_console.py&utm_term=top)
 #
 # ## Enterprise Data File
 # Enterprise (fully-featured) data files are typically released by 51Degrees four days a week
@@ -199,7 +199,7 @@ class DataFileUpdateConsole():
 			logger.log("error",
 				"In order to test this example you will need a 51Degrees Enterprise "
 				"license which can be obtained on a trial basis or purchased from our\n"
-				"pricing page http://51degrees.com/pricing. You must supply the license "
+				"pricing page https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-datafileupdate_console.py&utm_term=license-key-required. You must supply the license "
 				"key as an argument to this program, or as an environment or system variable "
 				f"named '{UPDATE_EXAMPLE_LICENSE_KEY_NAME}'")
 			raise Exception("No license key available")
@@ -281,7 +281,7 @@ class DataFileUpdateConsole():
 			# to notify when update complete
 			data_file_update_service = update_service,
 			# For automatic updates to work you will need to provide a license key.
-			# A license key can be obtained with a subscription from https://51degrees.com/pricing
+			# A license key can be obtained with a subscription from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-datafileupdate_console.py&utm_term=run
 			licence_keys = license_key,
 			# Enable update on startup, the auto update system
 			# will be used to check for an update before the

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/gettingstarted_console.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/gettingstarted_console.py
@@ -51,15 +51,15 @@ class GettingStartedConsole():
         # In this example, we use the DeviceDetectionPipelineBuilder
         # and configure it in code. For more information about
         # pipelines in general see the documentation at
-        # https://51degrees.com/documentation/4.3/_concepts__configuration__builders__index.html
+        # https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_console.py&utm_term=run
         pipeline = DeviceDetectionPipelineBuilder(
             data_file_path = data_file,
             # We use the low memory profile as its performance is
             # sufficient for this example. See the documentation for
             # more detail on this and other configuration options:
-            # https://51degrees.com/documentation/4.3/_device_detection__features__performance_options.html
-            # https://51degrees.com/documentation/4.3/_features__automatic_datafile_updates.html
-            # https://51degrees.com/documentation/4.3/_features__usage_sharing.html
+            # https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_console.py&utm_term=run
+            # https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_console.py&utm_term=run
+            # https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_console.py&utm_term=run
             performance_profile = "MaxPerformance",
             # inhibit sharing usage for this test, usually this
             # should be set "true"
@@ -111,7 +111,7 @@ class GettingStartedConsole():
 
         # Display the results of the detection, which are called
         # device properties. See the property dictionary at
-        # https://51degrees.com/developers/property-dictionary
+        # https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_console.py&utm_term=analyseevidence
         # for details of all available properties.
         self.outputValue("Mobile Device", device.ismobile, message)
         self.outputValue("Platform Name", device.platformname, message)
@@ -141,7 +141,7 @@ def main(argv):
     # Note that the Lite data file is only used for illustration, and has
     # limited accuracy and capabilities.
     # Find out about the Enterprise data file on our pricing page:
-    # https://51degrees.com/pricing
+    # https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_console.py&utm_term=main
     data_file = argv[0] if len(argv) > 0 else ExampleUtils.find_file(LITE_DATAFILE_NAME)
 
     # Configure a logger to output to the console.

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/gettingstarted_web/app.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/gettingstarted_web/app.py
@@ -58,7 +58,7 @@
 # ```
 # 
 # Results can also be accessed in client-side code by using the `fod` object. See the 
-# [JavaScriptBuilderElementBuilder](https://51degrees.com/pipeline-python/4.3/classpipeline-python_1_1fiftyone__pipeline__core_1_1fiftyone__pipeline__core_1_1javascriptbuilde778a9036818b19ab55d981a40be4a4d7.html)
+# [JavaScriptBuilderElementBuilder](https://51degrees.com/pipeline-python/4.3/classpipeline-python_1_1fiftyone__pipeline__core_1_1fiftyone__pipeline__core_1_1javascriptbuilde778a9036818b19ab55d981a40be4a4d7.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_web-app.py&utm_term=top)
 # for details on available settings such as changing the `fod` name.
 # ```{js}
 # window.onload = function () {
@@ -146,7 +146,7 @@ class GettingStartedWeb():
         # requested. So set whatever headers are required by the browser in
         # order to return the evidence needed by the pipeline.
         # More info on this can be found at
-        # https://51degrees.com/blog/user-agent-client-hints
+        # https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_web-app.py&utm_term=server
 
         set_response_header(flowdata, response)
 

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/gettingstarted_web/templates/index.html
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/gettingstarted_web/templates/index.html
@@ -72,7 +72,7 @@
             from the 
             <a href="https://github.com/51Degrees/device-detection-data">device-detection-data</a>
             repository on GitHub. Find out about the Enterprise data file, which includes automatic 
-            daily updates, on our <a href="https://51degrees.com/pricing">pricing page</a>.
+            daily updates, on our <a href="https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_web-templates-index.html&utm_term=client-hints">pricing page</a>.
         </div>
     {% endif %}
 
@@ -183,7 +183,7 @@
                 WARNING: You are using the free 'Lite' data file. This does not include the client-side
                 evidence capabilities of the paid-for data file, so you will not see any additional
                 data below. Find out about the Enterprise data file on our
-                <a href="https://51degrees.com/pricing">pricing page</a>.
+                <a href="https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_web-templates-index.html&utm_term=client-side-evidence-and-apple-models">pricing page</a>.
             </div>
         {% endif %}
     </div>

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/match_metrics.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/match_metrics.py
@@ -31,9 +31,9 @@
 # process - reducing the number of components required to return the properties requested reduces
 # the overall time taken.
 # 
-# There is a [discussion](https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Performance)
+# There is a [discussion](https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-match_metrics.py&utm_term=top#DeviceDetection_Hash_DataSetProduction_Performance)
 # of metrics and controlling performance on our web site. See also the (performance options)
-# [https://51degrees.com/documentation/_device_detection__features__performance_options.html]
+# [https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-match_metrics.py&utm_term=top]
 # page.
 # # Location
 # This example is available in full on [GitHub](https://github.com/51Degrees/device-detection-python/blob/main/fiftyone_devicedetection_examples/fiftyone_devicedetection_examples/onpremise/match_metrics.py].
@@ -77,12 +77,12 @@ class MatchMetricsConsole():
             # in the device ID value.
             #restricted_properties=["ismobile", "hardwarename", "browsername"],
             # If using the full on-premise data file this property will be
-            # present in the data file. See https://51degrees.com/pricing
+            # present in the data file. See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-match_metrics.py&utm_term=run
             # Only use the predictive graph to better handle variances
             # between the training data and the target User-Agent string.
             # For a more detailed description of the differences between
             # performance and predictive, see
-            # https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Performance
+            # https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-match_metrics.py&utm_term=run#DeviceDetection_Hash_DataSetProduction_Performance
             use_predictive_graph = True,
             use_performance_graph = False,
             # We want to show the matching evidence characters as part of this example, so we have to set
@@ -116,7 +116,7 @@ class MatchMetricsConsole():
 
 
         output("--- Listing all available properties, by component, by property name ---")
-        output("For a discussion of what the match properties mean, see: https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Performance\n")
+        output("For a discussion of what the match properties mean, see: https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-match_metrics.py&utm_term=match-properties-discussion#DeviceDetection_Hash_DataSetProduction_Performance\n")
 
         # get the properties available from the DeviceDetection engine
         # which has the key "device". For the sake of illustration we will
@@ -178,7 +178,7 @@ def main(argv):
     # Note that the Lite data file is only used for illustration, and has
     # limited accuracy and capabilities.
     # Find out about the Enterprise data file on our pricing page:
-    # https://51degrees.com/pricing
+    # https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-match_metrics.py&utm_term=main
     data_file = argv[0] if len(argv) > 0 else ExampleUtils.find_file(LITE_DATAFILE_NAME)
     
     # Configure a logger to output to the console.

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/metadata_console.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/metadata_console.py
@@ -60,15 +60,15 @@ class MetaDataConsole():
         # In this example, we use the DeviceDetectionPipelineBuilder
         # and configure it in code. For more information about
         # pipelines in general see the documentation at
-        # http://51degrees.com/documentation/4.3/_concepts__configuration__builders__index.html
+        # https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-metadata_console.py&utm_term=run
         pipeline = DeviceDetectionPipelineBuilder(
             data_file_path = data_file,
             # We use the low memory profile as its performance is
             # sufficient for this example. See the documentation for
             # more detail on this and other configuration options:
-            # http://51degrees.com/documentation/4.3/_device_detection__features__performance_options.html
-            # http://51degrees.com/documentation/4.3/_features__automatic_datafile_updates.html
-            # http://51degrees.com/documentation/4.3/_features__usage_sharing.html
+            # https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-metadata_console.py&utm_term=run
+            # https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-metadata_console.py&utm_term=run
+            # https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-metadata_console.py&utm_term=run
             performance_profile = "LowMemory",
             # inhibit sharing usage for this test, usually this
             # should be set "true"
@@ -118,7 +118,7 @@ def main(argv):
     # Note that the Lite data file is only used for illustration, and has
     # limited accuracy and capabilities.
     # Find out about the Enterprise data file on our pricing page:
-    # https://51degrees.com/pricing
+    # https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-metadata_console.py&utm_term=main
     data_file = argv[0] if len(argv) > 0 else ExampleUtils.find_file(LITE_DATAFILE_NAME)
     
     # Configure a logger to output to the console.

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/offlineprocessing.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/offlineprocessing.py
@@ -73,15 +73,15 @@ class OfflineProcessing():
         # In this example, we use the DeviceDetectionPipelineBuilder
         # and configure it in code. For more information about
         # pipelines in general see the documentation at
-        # http://51degrees.com/documentation/4.3/_concepts__configuration__builders__index.html
+        # https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-offlineprocessing.py&utm_term=run
         pipeline = DeviceDetectionPipelineBuilder(
             data_file_path = data_file,
             # We use the low memory profile as its performance is
             # sufficient for this example. See the documentation for
             # more detail on this and other configuration options:
-            # http://51degrees.com/documentation/4.3/_device_detection__features__performance_options.html
-            # http://51degrees.com/documentation/4.3/_features__automatic_datafile_updates.html
-            # http://51degrees.com/documentation/4.3/_features__usage_sharing.html
+            # https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-offlineprocessing.py&utm_term=run
+            # https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-offlineprocessing.py&utm_term=run
+            # https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-offlineprocessing.py&utm_term=run
             performance_profile = "LowMemory",
             # inhibit sharing usage for this test, usually this
             # should be set "true"
@@ -92,7 +92,7 @@ class OfflineProcessing():
             # in order to help us improve detection of new devices/browsers/etc, then
             # this additional data will need to be collected and included as evidence
             # to the Pipeline. See
-            # https://51degrees.com/documentation/_features__usage_sharing.html#Low_Level_Usage_Sharing
+            # https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-offlineprocessing.py&utm_term=run#Low_Level_Usage_Sharing
             # for more details on this.
             usage_sharing = False,
             # Inhibit auto-update of the data file for this example
@@ -190,7 +190,7 @@ def main(argv):
     # Note that the Lite data file is only used for illustration, and has
     # limited accuracy and capabilities.
     # Find out about the Enterprise data file on our pricing page:
-    # https://51degrees.com/pricing
+    # https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-offlineprocessing.py&utm_term=main
     data_file = argv[0] if len(argv) > 0 else ExampleUtils.find_file(LITE_DATAFILE_NAME)
     # This file contains the 20,000 most commonly seen combinations of header values 
     # that are relevant to device detection. For example, User-Agent and UA-CH headers.

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/useragentclienthints-web.py
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/useragentclienthints-web.py
@@ -186,7 +186,7 @@ def server():
     # requested. So set whatever headers are required by the browser in
     # order to return the evidence needed by the pipeline.
     # More info on this can be found at
-    # https://51degrees.com/blog/user-agent-client-hints
+    # https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-useragentclienthints-web.py&utm_term=server
 
     response = set_response_header(flowdata, response)
 

--- a/fiftyone_devicedetection_onpremise/readme.md
+++ b/fiftyone_devicedetection_onpremise/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees Device Detection Engines - On-Premise
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_onpremise-readme.md&utm_term=51degrees-device-detection-engines-on-premise "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
 
-[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "View all available properties and values")
+[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_onpremise-readme.md&utm_term=51degrees-device-detection-engines-on-premise "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_onpremise-readme.md&utm_term=51degrees-device-detection-engines-on-premise "View all available properties and values")
 
 ## Introduction
 
@@ -56,7 +56,7 @@ fd.process()
 print(fd.device.ismobile.value())
 ```
 
-For more in-depth examples, check out the [examples](https://51degrees.com/device-detection-python/examples.html) page in the documentation.
+For more in-depth examples, check out the [examples](https://51degrees.com/device-detection-python/examples.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_onpremise-readme.md&utm_term=from-pypi) page in the documentation.
 
 ### From GitHub
 

--- a/fiftyone_devicedetection_onpremise/src/fiftyone_devicedetection_onpremise/devicedetection_onpremise.py
+++ b/fiftyone_devicedetection_onpremise/src/fiftyone_devicedetection_onpremise/devicedetection_onpremise.py
@@ -148,7 +148,7 @@ class DeviceDetectionOnPremise(Engine):
             self.data = data
 
         if not licence_keys and licence_keys != "":
-            raise Exception("licence key is required. A key can be obtained from the 51Degrees website: https://51degrees.com/pricing. If you do not wish to use a key then you can specify an empty string, but this will cause automatic updates to be disabled.")
+            raise Exception("licence key is required. A key can be obtained from the 51Degrees website: https://51degrees.com/pricing?utm_source=code&utm_medium=comment&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_onpremise-src-fiftyone_devicedetection_onpremise-devicedetection_onpremise.py&utm_term=licence-key-required. If you do not wish to use a key then you can specify an empty string, but this will cause automatic updates to be disabled.")
 
         #   Create SWIG wrapper vector for restricted properties and add
 

--- a/fiftyone_devicedetection_shared/readme.md
+++ b/fiftyone_devicedetection_shared/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees Device Detection Engines - Shared
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_shared-readme.md&utm_term=51degrees-device-detection-engines-shared "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
 
-[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "View all available properties and values")
+[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_shared-readme.md&utm_term=51degrees-device-detection-engines-shared "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_shared-readme.md&utm_term=51degrees-device-detection-engines-shared "View all available properties and values")
 
 ## Introduction
 

--- a/fiftyone_devicedetection_shared/setup.py
+++ b/fiftyone_devicedetection_shared/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     version=read("version.txt"),
     author_email="engineering@51degrees.com",
     author="51Degrees Engineering",
-    url="https://51degrees.com/",
+    url="https://51degrees.com/?utm_source=pypi&utm_medium=package&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_shared-setup.py&utm_term=url",
     description=("The 51Degrees Pipeline API is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines). This project contains 51Degrees Device Detection engines that can be used with the Pipeline API."),
     long_description=read("readme.md"),
     long_description_content_type='text/markdown',

--- a/fiftyone_devicedetection_shared/src/fiftyone_devicedetection_shared/example_constants.py
+++ b/fiftyone_devicedetection_shared/src/fiftyone_devicedetection_shared/example_constants.py
@@ -51,7 +51,7 @@ EVIDENCE_VALUES = [
 
         # Links:
         # - [getHighEntropyValues()](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
-        # - [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints)
+        # - [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints?utm_source=code&utm_medium=comment&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_shared-src-fiftyone_devicedetection_shared-example_constants.py&utm_term=evidence_values)
         # - [OpenRTB 2.6 spec](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectuseragent)
 
         # 51Degrees historically used HTTP header map to represent User-Agent Client Hints and expected the evidence to

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees Device Detection Engines
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=readme.md&utm_term=51degrees-device-detection-engines "THE Fastest and Most Accurate Device Detection") **v4 Device Detection Python**
 
-[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=repository&utm_content=property_dictionary&utm_campaign=python-open-source "View all available properties and values")
+[Developer Documentation](https://51degrees.com/device-detection-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=readme.md&utm_term=51degrees-device-detection-engines "Developer Documentation") | [Available Properties](https://51degrees.com/resources/property-dictionary?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=readme.md&utm_term=51degrees-device-detection-engines "View all available properties and values")
 
 ## Introduction
 
@@ -24,8 +24,8 @@ git submodule update --init --recursive
 
 ## Dependencies
 
-For runtime dependencies, see our [dependencies](http://51degrees.com/documentation/_info__dependencies.html) page.
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows 
+For runtime dependencies, see our [dependencies](https://51degrees.com/documentation/_info__dependencies.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=readme.md&utm_term=dependencies) page.
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=readme.md&utm_term=dependencies) page shows 
 the Python versions that we currently test against. The software may run fine against other versions, 
 but additional caution should be applied.
 
@@ -35,17 +35,17 @@ The API can either use our cloud service to get its data or it can use a local (
 
 #### Cloud
 
-You will require a [resource key](https://51degrees.com/documentation/_info__resource_keys.html)
+You will require a [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=readme.md&utm_term=cloud)
 to use the Cloud API. You can create resource keys using our 
-[configurator](https://configure.51degrees.com/), see our 
-[documentation](https://51degrees.com/documentation/_concepts__configurator.html) on how to use this.
+[configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=readme.md&utm_term=cloud), see our 
+[documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=readme.md&utm_term=cloud) on how to use this.
 
 #### On-Premise
 
 In order to perform device detection on-premise, you will need to use a 51Degrees data file. 
 This repository includes a free, 'lite' file in the 'device-detection-data' sub-module that has a 
 significantly reduced set of properties. To obtain a file with a more complete set of device 
-properties see the [51Degrees website](https://51degrees.com/pricing). If you want to use the lite 
+properties see the [51Degrees website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-python&utm_content=readme.md&utm_term=on-premise). If you want to use the lite 
 file, you will need to install [GitLFS](https://git-lfs.github.com/):
 
 ```


### PR DESCRIPTION
## What

Tags navigational links to `51degrees.com` and `configure.51degrees.com` across all sub-packages with the standard UTM scheme so the Content Team can trace traffic to its exact source.

## Scheme

`?utm_source=<source>&utm_medium=<medium>&utm_campaign=device-detection-python&utm_content=<file-slug>&utm_term=<location>`

- **utm_source**: `github` for markdown rendered on github.com, `code` for source/example comments and user-visible strings, `pypi` for package metadata fields.
- **utm_medium**: `readme` for README files, `example` for files under the examples package, `comment` for library source comments and runtime messages, `package` for `setup.py` metadata.
- **utm_campaign**: `device-detection-python`.
- **utm_content**: the file path slug.
- **utm_term**: location within the file. For markdown the nearest heading, for source the enclosing function/class/variable, and for runtime messages (errors, warnings, console output) a message-meaning slug such as `resource-key-required`, `licence-key-required`, `data-file-age-warning`, or `lite-data-file` so the clicked message can be identified.

Also normalises `http` to `https`, protocol-relative `//51degrees.com` to `https`, moves the retired `Logo.ashx` logo to `/img/logo.png`, replaces the old `*-open-source` query scheme, and un-versions old `/documentation/4.3/` and `/documentation/4.4/` links. Configure share-key paths are preserved with the query appended after them.

Functional endpoints (`distributor`, `cloud`, `devices-v4`), data/usage-sharing URLs, and test fixtures are deliberately left untouched.

## Lint

Adds `.github/workflows/utm-link-lint.yml`, which runs the shared `utm-lint.ps1` from `51Degrees/common-ci` on pull requests and pushes to keep these links conformant.