### PR TITLE
fix(utm): tag the contact-us links merged from #315

### DIFF
--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/gettingstarted_web/templates/index.html
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/gettingstarted_web/templates/index.html
@@ -147,8 +147,8 @@
     </div>
 
     <div class="c-eg-message">
-      <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us">Contact us</a> to discuss requirements.</p>
-      <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+      <p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_web-templates-index.html&utm_term=try-on-premise">Contact us</a> to discuss requirements.</p>
+      <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-gettingstarted_web-templates-index.html&utm_term=try-on-premise">Contact us</a>
     </div>
 </div>
 

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/useragentclienthints_web/templates/index.html
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/cloud/useragentclienthints_web/templates/index.html
@@ -100,7 +100,7 @@
         </table>
     </div>
 
-    <div class="c-eg-message"><p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us">Contact us</a> to discuss requirements.</p><a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a></div>
+    <div class="c-eg-message"><p class="c-eg-message__text">Want to try on-premise? <a href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-useragentclienthints_web-templates-index.html&utm_term=try-on-premise">Contact us</a> to discuss requirements.</p><a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-cloud-useragentclienthints_web-templates-index.html&utm_term=try-on-premise">Contact us</a></div>
 </div>
 
 <script>

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/gettingstarted_web/templates/index.html
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/gettingstarted_web/templates/index.html
@@ -158,8 +158,8 @@
 
     {% if utils.get_data_file_tier(data.pipeline.get_element("device")) == "Lite" %}
         <div class="c-eg-message">
-          <p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
-          <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+          <p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_web-templates-index.html&utm_term=paid-data-file">Contact us</a> to explore the options.</p>
+          <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-gettingstarted_web-templates-index.html&utm_term=paid-data-file">Contact us</a>
         </div>
     {% endif %}
 </div>

--- a/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/useragentclienthints_web/templates/index.html
+++ b/fiftyone_devicedetection_examples/src/fiftyone_devicedetection_examples/onpremise/useragentclienthints_web/templates/index.html
@@ -99,7 +99,7 @@
     </div>
 
     {% if utils.get_data_file_tier(data.pipeline.get_element("device")) == "Lite" %}
-        <div class="c-eg-message"><p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p><a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a></div>
+        <div class="c-eg-message"><p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-useragentclienthints_web-templates-index.html&utm_term=paid-data-file">Contact us</a> to explore the options.</p><a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-python&utm_content=fiftyone_devicedetection_examples-src-fiftyone_devicedetection_examples-onpremise-useragentclienthints_web-templates-index.html&utm_term=paid-data-file">Contact us</a></div>
     {% endif %}
 </div>
 


### PR DESCRIPTION
Follow-up to #315. The free-tier contact-us banner links merged just before the UTM tags were applied, so `main` currently carries untagged 51degrees.com navigational links and fails the utm-link-lint check. This adds the standard five UTM parameters (source/medium/campaign/content/term) to each contact-us link. No other changes.